### PR TITLE
[VM Cleanup] Remove VM Runtime + VM Resource

### DIFF
--- a/Context.cs
+++ b/Context.cs
@@ -34,7 +34,7 @@ namespace VirtualGuardDevirt
                 var imageBuilder = new ManagedPEImageBuilder();
 
                 var factory = new DotNetDirectoryFactory();
-                factory.MetadataBuilderFlags = MetadataBuilderFlags.PreserveAll;
+                //factory.MetadataBuilderFlags = MetadataBuilderFlags.PreserveAll; //Doesn't looks like needed after file processing.
                 imageBuilder.DotNetDirectoryFactory = factory;
 
                 module.Write(filename, imageBuilder);

--- a/Protections/CrocodileVM/AnalyzeMethod.cs
+++ b/Protections/CrocodileVM/AnalyzeMethod.cs
@@ -1,4 +1,5 @@
-﻿using AsmResolver.DotNet.Collections;
+﻿using AsmResolver.DotNet;
+using AsmResolver.DotNet.Collections;
 using AsmResolver.DotNet.Signatures.Types;
 using AsmResolver.PE.DotNet.Cil;
 using System.Collections.Generic;
@@ -41,6 +42,7 @@ namespace VirtualGuardDevirt.Protections.CrocodileVM
                         }
                     }
                 }
+                if(type.FullName.Contains("A4FD01")) VM.VMType = type;
             }
         }
     }

--- a/Protections/CrocodileVM/AnalyzeMethod.cs
+++ b/Protections/CrocodileVM/AnalyzeMethod.cs
@@ -42,7 +42,7 @@ namespace VirtualGuardDevirt.Protections.CrocodileVM
                         }
                     }
                 }
-                if(type.FullName.Contains("A4FD01")) VM.VMType = type;
+                if(type.FullName == "A4FD01") VM.VMType = type;
             }
         }
     }

--- a/Protections/CrocodileVM/AnalyzeResources.cs
+++ b/Protections/CrocodileVM/AnalyzeResources.cs
@@ -10,6 +10,7 @@ namespace VirtualGuardDevirt.Protections.CrocodileVM
         {
             ManifestResource resource = (from x in module.Resources where x.Name == "crocodile" select x).First();
             VM.CrocodileBytecode = resource.GetData();
+            VM.VMResource = resource;
         }
     }
 }

--- a/Protections/CrocodileVM/InitializeReplace.cs
+++ b/Protections/CrocodileVM/InitializeReplace.cs
@@ -53,6 +53,7 @@ namespace VirtualGuardDevirt.Protections.CrocodileVM
                 }
             }
             module.TopLevelTypes.Remove(VM.VMType);
+            module.Resources.Remove(VM.VMResource);
         }
 
         public static List<CilInstruction> Disassemble(VMMethod _method, CilLocalVariableCollection methodLocalVars)

--- a/Protections/CrocodileVM/InitializeReplace.cs
+++ b/Protections/CrocodileVM/InitializeReplace.cs
@@ -8,6 +8,7 @@ using AsmResolver.PE.DotNet.Metadata.Tables;
 using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using VirtualGuardDevirt.Protections.CrocodileVM.VMData;
 using static VirtualGuardDevirt.Context;
 using static VirtualGuardDevirt.Logger;
@@ -51,6 +52,7 @@ namespace VirtualGuardDevirt.Protections.CrocodileVM
                     Console.WriteLine(instr);
                 }
             }
+            module.TopLevelTypes.Remove(VM.VMType);
         }
 
         public static List<CilInstruction> Disassemble(VMMethod _method, CilLocalVariableCollection methodLocalVars)

--- a/Protections/CrocodileVM/VM.cs
+++ b/Protections/CrocodileVM/VM.cs
@@ -10,6 +10,7 @@ namespace VirtualGuardDevirt.Protections.CrocodileVM
         public static Dictionary<int, List<VMInstruction>> Blocks = new Dictionary<int, List<VMInstruction>>();
         public static List<VMMethod> MethodVirt = new List<VMMethod>();
         public static TypeDefinition VMType = null;
+        public static ManifestResource VMResource = null;
 
         internal static void Execute()
         {

--- a/Protections/CrocodileVM/VM.cs
+++ b/Protections/CrocodileVM/VM.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using AsmResolver.DotNet;
+using System.Collections.Generic;
 using VirtualGuardDevirt.Protections.CrocodileVM.VMData;
 
 namespace VirtualGuardDevirt.Protections.CrocodileVM
@@ -8,6 +9,7 @@ namespace VirtualGuardDevirt.Protections.CrocodileVM
         public static byte[] CrocodileBytecode;
         public static Dictionary<int, List<VMInstruction>> Blocks = new Dictionary<int, List<VMInstruction>>();
         public static List<VMMethod> MethodVirt = new List<VMMethod>();
+        public static TypeDefinition VMType = null;
 
         internal static void Execute()
         {

--- a/Protections/SpiderVM/AnalyzeMethod.cs
+++ b/Protections/SpiderVM/AnalyzeMethod.cs
@@ -41,6 +41,7 @@ namespace VirtualGuardDevirt.Protections.SpiderVM
                         }
                     }
                 }
+                if (type.FullName.Contains("9")) VM.VMType = type;
             }
         }
     }

--- a/Protections/SpiderVM/AnalyzeMethod.cs
+++ b/Protections/SpiderVM/AnalyzeMethod.cs
@@ -41,7 +41,7 @@ namespace VirtualGuardDevirt.Protections.SpiderVM
                         }
                     }
                 }
-                if (type.FullName.Contains("9")) VM.VMType = type;
+                if (type.FullName == "9") VM.VMType = type;
             }
         }
     }

--- a/Protections/SpiderVM/AnalyzeResources.cs
+++ b/Protections/SpiderVM/AnalyzeResources.cs
@@ -10,6 +10,7 @@ namespace VirtualGuardDevirt.Protections.SpiderVM
         {
             ManifestResource resource = (from x in module.Resources where x.Name == "spider" select x).First();
             VM.SpiderBytecode = resource.GetData();
+            VM.VMResource = resource;
         }
     }
 }

--- a/Protections/SpiderVM/InitializeReplace.cs
+++ b/Protections/SpiderVM/InitializeReplace.cs
@@ -45,6 +45,7 @@ namespace VirtualGuardDevirt.Protections.SpiderVM
                     Console.WriteLine(instr);
                 }
                 module.TopLevelTypes.Remove(VM.VMType);
+                module.Resources.Remove(VM.VMResource);
             }
         }
 

--- a/Protections/SpiderVM/InitializeReplace.cs
+++ b/Protections/SpiderVM/InitializeReplace.cs
@@ -44,6 +44,7 @@ namespace VirtualGuardDevirt.Protections.SpiderVM
                 {
                     Console.WriteLine(instr);
                 }
+                module.TopLevelTypes.Remove(VM.VMType);
             }
         }
 

--- a/Protections/SpiderVM/VM.cs
+++ b/Protections/SpiderVM/VM.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using AsmResolver.DotNet;
+using System.Collections.Generic;
 using VirtualGuardDevirt.Protections.SpiderVM.VMData;
 
 namespace VirtualGuardDevirt.Protections.SpiderVM
@@ -8,6 +9,7 @@ namespace VirtualGuardDevirt.Protections.SpiderVM
         public static byte[] SpiderBytecode;
         public static Dictionary<int, List<VMInstruction>> Methods = new Dictionary<int, List<VMInstruction>>();
         public static List<VMMethod> MethodVirt = new List<VMMethod>();
+        public static TypeDefinition VMType = null;
 
         internal static void Execute()
         {

--- a/Protections/SpiderVM/VM.cs
+++ b/Protections/SpiderVM/VM.cs
@@ -10,6 +10,7 @@ namespace VirtualGuardDevirt.Protections.SpiderVM
         public static Dictionary<int, List<VMInstruction>> Methods = new Dictionary<int, List<VMInstruction>>();
         public static List<VMMethod> MethodVirt = new List<VMMethod>();
         public static TypeDefinition VMType = null;
+        public static ManifestResource VMResource = null;
 
         internal static void Execute()
         {


### PR DESCRIPTION
Apparently `PreserveAll` is not required or at least not for your samples ?

I feel like it's more clean without the VM Runtime on it. Do you have more samples ? I doubt the renaming stay the same everytime.

Preview:
[![](https://i.imgur.com/n2Nksl1.gif)](https://i.imgur.com/n2Nksl1.mp4)
